### PR TITLE
Fix f-string issue for Python < 3.12

### DIFF
--- a/common.py
+++ b/common.py
@@ -9,7 +9,7 @@ def stringify_md(doc: Document) -> str:
     return_str += f"## 主旨\n"
     return_str += f"{doc.subject}\n"
     return_str += f"## 說明\n"
-    return_str += f"{doc.description.stringify("-", ignore_section_type=True)}\n"
+    return_str += f"{doc.description.stringify('-', ignore_section_type=True)}\n"
 
     if doc.act:
         return_str += f"## 擬辦\n"

--- a/di_parser/core.py
+++ b/di_parser/core.py
@@ -94,6 +94,8 @@ class Section(DocumentItem):
 
     def stringify(self, overwrite_sequence_bullet: Optional[str] = None, ignore_section_type: bool = False) -> str:
         
+        section_type = self.section_type + '：\n' if not ignore_section_type else ''
+
         seprator = "\n"
 
         # Recursively stringify the items in the subSequence.
@@ -103,7 +105,7 @@ class Section(DocumentItem):
             # If either of them are empty, we don't need a new line.
             seprator = ""
 
-        return f"{self.section_type + '：\n' if not ignore_section_type else ''}" + self.content + seprator + sub_content
+        return f"{section_type}" + self.content + seprator + sub_content
 
     def __str__(self):
         return self.stringify()

--- a/di_parser/core.py
+++ b/di_parser/core.py
@@ -185,12 +185,36 @@ class Document:
         receiver_str = ""
         if self.receiver:
             receiver_str = "\n".join([str(r) for r in self.receiver])
-    
+
+        receiver_str_with_newline = ""
+        if receiver_str:
+            receiver_str_with_newline = "\n" + receiver_str
+        else:
+            receiver_str_with_newline = ""
+
+        org_str = ""
+        if self.organization:
+            org_str = self.organization
+        else:
+            org_str = "<n/a>"
+
+        date_str = ""
+        if self.date:
+            date_str = self.date
+        else:
+            date_str = "<n/a>"
+
+        act_str_with_newline = ""
+        if self.act:
+            act_str_with_newline = "\n" + str(self.act)
+        else:
+            act_str_with_newline = ""
+
         # Building return string.
-        return_str = f"{self.document_type} | {self.organization if self.organization else "<n/a>"} | {self.date if self.date else "<n/a>"}\n{self.subject}\n" + \
+        return_str = f"{self.document_type} | {org_str} | {date_str}\n" + \
             f"{str(self.description)}" + \
-            f"{'\n' + str(self.act) if self.act else ""}" + \
-            f"{'\n' + receiver_str if receiver_str else ""}"
+            f"{act_str_with_newline}" + \
+            f"{receiver_str_with_newline}"
         
         return return_str
     

--- a/di_parser/core.py
+++ b/di_parser/core.py
@@ -212,9 +212,9 @@ class Document:
 
         # Building return string.
         return_str = f"{self.document_type} | {org_str} | {date_str}\n" + \
-            f"{str(self.description)}" + \
-            f"{act_str_with_newline}" + \
-            f"{receiver_str_with_newline}"
+                     f"{str(self.description)}" + \
+                     f"{act_str_with_newline}" + \
+                     f"{receiver_str_with_newline}"
         
         return return_str
     


### PR DESCRIPTION
The current parser generates an error when executed with Python versions below 3.12.
We have resolved the issue related to f-strings and successfully tested the parser with Python 3.11.5.

All operations are now functioning as expected.